### PR TITLE
[TECH] Add read models for user ressource

### DIFF
--- a/app/models/user-detailed-profile.js
+++ b/app/models/user-detailed-profile.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+
+const { Model, attr } = DS;
+
+export default Model.extend( {
+  name:    attr('string'),
+  lastname:    attr('string'),
+  email:    attr('string'),
+  password: attr('string'),
+
+});

--- a/app/models/user-visit-card.js
+++ b/app/models/user-visit-card.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+const { Model, attr } = DS;
+
+export default Model.extend( {
+  name:    attr('string'),
+  lastname:    attr('string'),
+  email:    attr('string'),
+});

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -30,6 +30,9 @@ const Validations = buildValidations({
 
 
   export default Model.extend(Validations, {
+    name:    attr('string'),
+    lastname:    attr('string'),
     email:    attr('string'),
     password: attr('string'),
+
   });

--- a/app/router.js
+++ b/app/router.js
@@ -15,6 +15,7 @@ Router.map(function() {
   });
   this.route('sign-up');
   this.route('login');
+  this.route('userVisitCard');
 });
 
 export default Router;

--- a/app/routes/user-visit-card.js
+++ b/app/routes/user-visit-card.js
@@ -1,0 +1,9 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+
+  async model() {
+    return this.store.findAll('user');
+  },
+
+});

--- a/app/templates/bands/band.hbs
+++ b/app/templates/bands/band.hbs
@@ -2,6 +2,10 @@
   <ul class="rr-nav">
     <li class="rr-navbar-item" data-test-rr="details-nav-item">{{link-to "Details" "bands.band.details"}}</li>
     <li class="rr-navbar-item" data-test-rr="songs-nav-item">{{link-to "Songs" "bands.band.songs"}}</li>
+    <li class="rr-navbar-item" data-test-rr="songs-nav-item">{{link-to "UserVisitCard" "userVisitCard"}}</li>
+    <li class="rr-navbar-item" data-test-rr="songs-nav-item">{{link-to "UserDetailedProfile" "UserDetailedProfile"}}</li>
+    <li class="rr-navbar-item" data-test-rr="songs-nav-item">{{link-to "User" "user"}}</li>
+
   </ul>
 </nav>
 {{outlet}}

--- a/app/templates/user-visit-card.hbs
+++ b/app/templates/user-visit-card.hbs
@@ -1,0 +1,1 @@
+<span class="ml1">this.model.name</span>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -14,8 +14,12 @@ export default function() {
   this.get('/bands/:id/songs', function(schema, request) {
     let id = request.params.id;
     return schema.songs.where({ bandId: id });
-  }); 
-  
+  });
+
+  this.get('/users', function(schema, request) {
+    return schema.users.all();
+  });
+
   this.post('/users');
 
   this.post('/token', function(schema, request) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9432,7 +9432,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9453,12 +9454,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9473,17 +9476,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9600,7 +9606,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9612,6 +9619,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9626,6 +9634,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9633,12 +9642,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9657,6 +9668,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9737,7 +9749,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9749,6 +9762,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9834,7 +9848,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9870,6 +9885,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9889,6 +9905,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9932,12 +9949,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/tests/unit/models/user-detailed-profile-test.js
+++ b/tests/unit/models/user-detailed-profile-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | user detailed profile', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('user-detailed-profile', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/user-visit-card-test.js
+++ b/tests/unit/models/user-visit-card-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | user visit card', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('user-visit-card', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/routes/user-visit-card-test.js
+++ b/tests/unit/routes/user-visit-card-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | UserVisitCard', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:user-visit-card');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Eviter de charger toute la grappe de donnée de la ressource User.
Des repository qui galère à construire des repository pseudo complet.
La peur de faire bouger une grosse ressource utilisé dans plein d’endroits différents
Avoir un objet du domaine générique qui tire plein de choses.

## :robot: Solution
Utiliser les read models pour séparer les commands write avec les queries en read

## :rainbow: Remarques
Pas d'api , on simule les retours d'api avec mirage

## :100: Pour tester

